### PR TITLE
Fix QuoteSlide display

### DIFF
--- a/components/presentation/slides/QuoteSlide.tsx
+++ b/components/presentation/slides/QuoteSlide.tsx
@@ -12,11 +12,11 @@ export function QuoteSlide({ slide }: QuoteSlideProps) {
   return (
     <SlideWrapper slideId={slide.id}>
       <div className="space-y-12 max-w-4xl">
-        <motion.blockquote 
+        <motion.blockquote
           variants={textVariants}
           className="text-5xl font-light text-white leading-relaxed italic"
         >
-          "{slide.quote}"
+          {slide.quote}
         </motion.blockquote>
         <motion.p 
           variants={textVariants}


### PR DESCRIPTION
## Summary
- display quotes correctly in the QuoteSlide component

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c43d8b3a083338e7c3a72b57789a4