### PR TITLE
Add video slide with QR code

### DIFF
--- a/components/presentation/SlideContent.tsx
+++ b/components/presentation/SlideContent.tsx
@@ -10,6 +10,7 @@ import {
   TimelineSlide,
   VisualSlide,
   DiagramSlide,
+  VideoSlide,
   HowDidWeGetHereSlide,
   PerceptronSlide,
   NeuralNetworkSlide,
@@ -52,6 +53,9 @@ export function SlideContent({ slide, isActive }: SlideContentProps) {
     
     case 'diagram':
       return <DiagramSlide slide={slide} />;
+
+    case 'video':
+      return <VideoSlide slide={slide} />;
     
     case 'how-did-we-get-here':
       return <HowDidWeGetHereSlide slide={slide} />;

--- a/components/presentation/slides.ts
+++ b/components/presentation/slides.ts
@@ -1,6 +1,6 @@
 export interface Slide {
   id: number;
-  type: 'title' | 'content' | 'timeline' | 'emoji' | 'bullets' | 'diagram' | 'quote' | 'visual' | 'how-did-we-get-here' | 'perceptron' | 'neural-network' | 'transformer' | 'final';
+  type: 'title' | 'content' | 'timeline' | 'emoji' | 'bullets' | 'diagram' | 'quote' | 'visual' | 'video' | 'how-did-we-get-here' | 'perceptron' | 'neural-network' | 'transformer' | 'final';
   title?: string;
   subtitle?: string;
   content?: string;
@@ -12,6 +12,8 @@ export interface Slide {
   quote?: string;
   author?: string;
   visual?: string;
+  videoUrl?: string;
+  qrUrl?: string;
   diagram?: {
     type: 'hierarchy' | 'flow' | 'nested' | 'concentric';
     items: Array<{
@@ -282,6 +284,13 @@ export const slides: Slide[] = [
   },
   {
     id: 37,
+    type: 'video',
+    title: 'Watch this demo',
+    videoUrl: 'https://www.youtube.com/embed/7xTGNNLPyMI?si=bLdR6gD8M-xc49_a',
+    qrUrl: 'https://youtu.be/7xTGNNLPyMI?si=bLdR6gD8M-xc49_a'
+  },
+  {
+    id: 38,
     type: 'final',
     title: 'Thank you!',
     subtitle: 'Questions?',

--- a/components/presentation/slides/VideoSlide.tsx
+++ b/components/presentation/slides/VideoSlide.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { SlideWrapper, textVariants } from './SlideWrapper';
+import { Slide } from '../slides';
+import QRCode from 'react-qr-code';
+
+interface VideoSlideProps {
+  slide: Slide;
+}
+
+export function VideoSlide({ slide }: VideoSlideProps) {
+  return (
+    <SlideWrapper slideId={slide.id}>
+      <div className="space-y-8 flex flex-col items-center">
+        {slide.title && (
+          <motion.h2
+            variants={textVariants}
+            className="text-6xl font-bold gradient-text leading-tight text-center"
+          >
+            {slide.title}
+          </motion.h2>
+        )}
+        {slide.videoUrl && (
+          <motion.iframe
+            variants={textVariants}
+            className="w-full max-w-3xl aspect-video rounded-lg"
+            src={slide.videoUrl}
+            title={slide.title ?? 'video'}
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+          />
+        )}
+        {slide.qrUrl && (
+          <motion.div variants={textVariants} className="w-32 h-32">
+            <QRCode value={slide.qrUrl} size={128} />
+          </motion.div>
+        )}
+      </div>
+    </SlideWrapper>
+  );
+}

--- a/components/presentation/slides/index.ts
+++ b/components/presentation/slides/index.ts
@@ -10,6 +10,7 @@ export { QuoteSlide } from './QuoteSlide';
 export { TimelineSlide } from './TimelineSlide';
 export { VisualSlide } from './VisualSlide';
 export { DiagramSlide } from './DiagramSlide';
+export { VideoSlide } from './VideoSlide';
 
 // Example of custom slide type (demonstrates extensibility)
 export { InteractiveSlide } from './InteractiveSlide';

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-hook-form": "^7.55.0",
     "react-resizable-panels": "^2.1.7",
     "recharts": "^2.15.1",
+    "react-qr-code": "^2.1.0",
     "sonner": "^2.0.3",
     "tailwind-merge": "^3.1.0",
     "tw-animate-css": "^1.2.5",


### PR DESCRIPTION
## Summary
- use `react-qr-code` to render QR codes in `VideoSlide`
- add `react-qr-code` dependency

## Testing
- `npm run lint` *(fails: command not found)*
- `npm install react-qr-code` *(fails: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685c523a45b08333973d6a2eb2859507